### PR TITLE
Remove additional `apk update` in Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV APCuBC_VERSION 1.0.3
 
 WORKDIR /etc/shlink
 
-RUN apk update && \
+RUN \
 
     # Install common php extensions
     docker-php-ext-install -j"$(nproc)" pdo_mysql calendar && \


### PR DESCRIPTION
Add the `apk add` commands come with `--no-cache`, which means they will
not use any local cache, thus we do not need to update the apk cache
manually, as it's just waste of time and disk sapce.

Before this adjustment, the image size was 329146597 bytes, after this
adjustmentm the image size is 327868534 bytes, a little bit smaller, and
also build faster.