### PR TITLE
Update default shlink version to v1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3.2-cli-alpine3.9
 LABEL maintainer="Alejandro Celaya <alejandro@alejandrocelaya.com>"
 
-ARG SHLINK_VERSION=v1.16.1
+ARG SHLINK_VERSION=1.16.1
 ENV SHLINK_VERSION ${SHLINK_VERSION}
 ENV APCu_VERSION 5.1.16
 ENV APCuBC_VERSION 1.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3.2-cli-alpine3.9
 LABEL maintainer="Alejandro Celaya <alejandro@alejandrocelaya.com>"
 
-ARG SHLINK_VERSION=1.15.1
+ARG SHLINK_VERSION=v1.16.1
 ENV SHLINK_VERSION ${SHLINK_VERSION}
 ENV APCu_VERSION 5.1.16
 ENV APCuBC_VERSION 1.0.4


### PR DESCRIPTION
I just noticed this seems to be taken care of in your build hook, but anyways, maybe you want to change it anyway. I'll just leave this here :)